### PR TITLE
chore: add dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,12 @@
   "bugs": {
     "url": "https://github.com/CMDco/Cabotage/issues"
   },
-  "homepage": "https://github.com/CMDco/Cabotage#readme"
+  "homepage": "https://github.com/CMDco/Cabotage#readme",
+  "devDependencies": {
+    "body-parser": "^1.15.2",
+    "express": "^4.14.0",
+    "express-graphql": "^0.6.1",
+    "graphql": "^0.8.2",
+    "socket.io": "^1.7.1"
+  }
 }


### PR DESCRIPTION
adds express, graphql, express-graphql, and body-parser to dev dependancies