### PR TITLE
added triggerType to cabotage

### DIFF
--- a/src/cabotage.js
+++ b/src/cabotage.js
@@ -118,6 +118,23 @@ function handleDisconnect(socketid){
   delete connected[socketid];
 }
 
+function triggerType(typename, obj){
+  if(otypes[typename] === undefined){
+    throw new Error(`triggerType :: There exists no registerd type named ${typename}`);
+  }
+  let uniqKeys = otypes[typename].keys;
+  let uniqIdentifier = uniqKeys.reduce((acc, curr) => {
+    return acc + curr + obj[curr];
+  }, '');
+  db[uniqIdentifier].forEach((socket) => {
+    if(connected[socket] !== undefined){
+      db[uniqIdentifier].forEach((socketid) => {
+        connected[socketid].emit(socketid, obj);
+      });
+    }
+  });
+}
+
 module.exports = {
   registerResolver,
   getRoot,

--- a/src/cabotage.js
+++ b/src/cabotage.js
@@ -145,5 +145,6 @@ module.exports = {
   registerType,
   parseSchema,
   handleSubscribe,
-  handleDisconnect
+  handleDisconnect,
+  triggerType
 };


### PR DESCRIPTION
triggerType abstracts the logic for emitting updates to the client. This method can be used in other parts of our library for more DRYness! Integration in other parts of the cabotage library will be coming next.