### PR TITLE
handle disconnect now properly removes jobs from jobqueue on client disconnect

### DIFF
--- a/src/client-sockets.js
+++ b/src/client-sockets.js
@@ -16,10 +16,12 @@ function unsubscribe() {
   socket.emit('unsubscribe', { socketid });
 }
 
-function graphql(uri, query, variables, callback){
+function graphql(query){
   socket.emit('mutation', { query });
 }
 
-subscribe('http://localhost:4000', '{ getMessage(id: 0) { content, author} }', null, function (data) {
-  console.log(data);
-});
+// subscribe('http://localhost:4000', '{ getMessage(id: 0) { content, author} }', null, function (data) {
+//   console.log(data);
+// });
+
+module.exports = {subscribe, unsubscribe, graphql};

--- a/src/jobqueue.js
+++ b/src/jobqueue.js
@@ -74,7 +74,7 @@ class Job {
     this.callback = pCallback;
     this.numPolls = 0;
     this.identifier = pIdentifier;
-    this.loopback = (pLoopback === undefined ? true : false);
+    this.loopback = (pLoopback === undefined ? pLoopback : false);
     this.lastResult;
   }
 

--- a/src/jobqueue.js
+++ b/src/jobqueue.js
@@ -15,6 +15,15 @@ class JobQueue {
     return this.jobQueue.splice(0,1)[0];
   }
 
+  removeJob(attribute, value){
+    for(let i = this.jobQueue.length-1; i >= 0; --i){
+      if(this.jobQueue[i][attribute] === value){
+        this.jobQueue.splice(i, 1);
+      }
+    }
+    return;
+  }
+
   getJobs() {
     return this.jobQueue;
   }
@@ -23,13 +32,13 @@ class JobQueue {
     return this.jobQueue.length;
   }
 
-  addObservable(name, callback, errCallback, completeCallback, loopback=true, interval = 100) {
+  addObservable(name, callback, errCallback, completeCallback, interval = 100) {
     if(!this.watchdogs[name]) {
       let subscribeCallback = (intervalTime) => {
         if(this.jobQueue.length > 0) {
           let currJob = this.takeJob();
           callback(currJob);
-          if(loopback) {
+          if(currJob.loopback) {
             this.addJob(currJob);
           }
         }
@@ -50,7 +59,7 @@ class JobQueue {
 }
 
 class Job {
-  constructor(pName, pTask, pCallback) {
+  constructor(pName, pTask, pCallback, pIdentifier, pLoopback) {
     this.name = pName;
     this.storedTask = pTask;
     this.task = (...args) => { 
@@ -64,6 +73,8 @@ class Job {
     };
     this.callback = pCallback;
     this.numPolls = 0;
+    this.identifier = pIdentifier;
+    this.loopback = (pLoopback === undefined ? true : false);
     this.lastResult;
   }
 

--- a/src/sockets.js
+++ b/src/sockets.js
@@ -20,11 +20,15 @@ function setup(server) {
       debug(`socket.on(disconnect) :: [${socket.id}] disconnected`);
     });
     socket.on('mutation', (data) => {
+      console.log(`socket event[mutation] :: recieved query from ${socket.id}\n${data}`);
       graphql.graphql(
         graphql.buildSchema(getSchema()),
         data.query,
         getRoot()
-      );
+      ).then((result) => {
+        console.log(`socket event[mutation] :: result for ${socket.id}\n${result}`);
+        console.log(result);
+      });
     });
   });
 }


### PR DESCRIPTION
- the loopback attribute now lives on the Job object #44
- the add job logic was updted to provide an identifier
- handleDisconenct now removes job corresponding to disconnected client #48 
- exported modules for react and fixed subscribe parameters